### PR TITLE
Fix mutating license list

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,14 @@
-var list = require('./licenses.json')
-list.license = list
+var licenses = require('./licenses.json')
+var list = Object.assign({}, licenses)
+list.license = licenses
+list.list = licenses
 list.find = (id) => {
 	if (typeof id !== 'string') {
 		throw new TypeError('Expected a string');
 	}
-	for (let license in list) {
+	for (let license in licenses) {
 		if (license.toLocaleLowerCase() === id.toLocaleLowerCase()) {
-			return list[license]
+			return licenses[license]
 		}
 	}
 	return false

--- a/test.js
+++ b/test.js
@@ -1,10 +1,13 @@
 const choosealicenseList = require('.')
 const assert = require('assert')
-
+const licenses = require('./licenses.json')
 
 assert.equal(choosealicenseList.find('mit').id, 'MIT')
 assert.equal(choosealicenseList.MIT.body.length > 0, true)
 assert.equal(choosealicenseList.hasOwnProperty('data'), true)
 assert.equal(choosealicenseList.MIT.permissions.length == 4, true)
+assert.equal(choosealicenseList.find('data'), false)
+assert.notStrictEqual(choosealicenseList.license, choosealicenseList)
+assert.strictEqual(choosealicenseList.list, licenses)
 
 console.log('Done!')


### PR DESCRIPTION
Hi!

I noticed that there is no way to get hold of _just the licenses_ (which I need to show a list of them), because the module mutates the imported JSON and adds properties to it.

This also lead to a bug where the find method would return a value for `data`, `find`, `license` etc (properties on the module, not the data).

This PR makes sure to not mutate the JSON directly, and also adds a `list` property that returns the raw licenses. I see that there is a `license` property that does the same job, but in my opinion it has a less than intuitive name 😆 

Thanks for creating this module!